### PR TITLE
Add defer attribute to script tag

### DIFF
--- a/src/FontAwesomeTags.php
+++ b/src/FontAwesomeTags.php
@@ -18,7 +18,7 @@ class FontAwesomeTags extends Tags
     {
         $kitUrl = FontAwesome::kit($this->params->get('token'))->get('url');
 
-        return "<script src='$kitUrl' crossorigin='anonymous'></script>";
+        return "<script defer src='$kitUrl' crossorigin='anonymous'></script>";
     }
 
     protected function output($icon): string


### PR DESCRIPTION
Hi @aerni,

I noticed that the plugin is currently not adding a `defer` attribute to the script tag. Since this is recommended for performance reasons even in the FontAwesome Docs (https://fontawesome.com/docs/web/dig-deeper/svg-async), I suggest adding it :)

In the meantime, we have patched it in for our client.