### PR TITLE
Add support for Statamic 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "statamic/cms": "^4.0"
+        "php": "^8.1",
+        "statamic/cms": "^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/FontAwesomeTags.php
+++ b/src/FontAwesomeTags.php
@@ -9,6 +9,7 @@ use Statamic\Tags\Tags;
 class FontAwesomeTags extends Tags
 {
     protected static $handle = 'font_awesome';
+    protected static $aliases = ['fa'];
 
     public function wildcard($icon): ?string
     {


### PR DESCRIPTION
This PR adds support for Statamic 5 while dropping support for Statamic 4. It also adds a handy new shorthand `fa` tag alias that can be used instead of the long `font_awesome` tag handle.