### PR TITLE
Fix `__PHP_Incomplete_Class` errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.3",
         "laravel/framework": "^12.0 || ^13.0",
-        "statamic/cms": "^6.0"
+        "statamic/cms": "^6.10"
     },
     "autoload": {
         "psr-4": {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace Aerni\FontAwesome;
 
+use Aerni\FontAwesome\Data\Icon;
+use Aerni\FontAwesome\Data\Icons;
+use Aerni\FontAwesome\Data\Kit;
 use Statamic\Providers\AddonServiceProvider;
 
 class ServiceProvider extends AddonServiceProvider
@@ -12,4 +15,13 @@ class ServiceProvider extends AddonServiceProvider
         ],
         'publicDirectory' => 'resources/dist',
     ];
+
+    public function register(): void
+    {
+        $this->registerSerializableClasses([
+            Icon::class,
+            Icons::class,
+            Kit::class,
+        ]);
+    }
 }


### PR DESCRIPTION
Register `Icon`, `Icons`, and `Kit` as serializable classes to prevent cache deserialization failures on apps using Laravel's `serializable_classes` restriction (introduced in [v12.53.0](https://github.com/laravel/framework/pull/58911)). Without this, cached objects deserialize as `__PHP_Incomplete_Class`, breaking the fieldtype. 

Bumps minimum Statamic version to `^6.10` which introduced `registerSerializableClasses` in https://github.com/statamic/cms/pull/14416.