### PR TITLE
Reduce memory usage for large icon sets

### DIFF
--- a/src/FontAwesome/AbstractFontAwesome.php
+++ b/src/FontAwesome/AbstractFontAwesome.php
@@ -6,6 +6,7 @@ use Aerni\FontAwesome\Contracts\FontAwesome;
 use Aerni\FontAwesome\Data\Icon;
 use Aerni\FontAwesome\Data\Icons;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
 
 abstract class AbstractFontAwesome implements FontAwesome
 {
@@ -18,7 +19,7 @@ abstract class AbstractFontAwesome implements FontAwesome
 
     public function styles(): Collection
     {
-        return $this->icons()->styles();
+        return Cache::rememberForever('font_awesome::styles', fn () => $this->icons()->styles());
     }
 
     protected function collectIcons(array $icons): Icons

--- a/src/FontAwesome/KitFontAwesome.php
+++ b/src/FontAwesome/KitFontAwesome.php
@@ -2,14 +2,13 @@
 
 namespace Aerni\FontAwesome\FontAwesome;
 
-use Aerni\FontAwesome\Contracts\FontAwesome;
 use Aerni\FontAwesome\Data\Icons;
 use Aerni\FontAwesome\Data\Kit;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 
-class KitFontAwesome extends AbstractFontAwesome implements FontAwesome
+class KitFontAwesome extends AbstractFontAwesome
 {
     protected string $apiEndpoint = 'https://api.fontawesome.com';
 

--- a/src/FontAwesome/LocalFontAwesome.php
+++ b/src/FontAwesome/LocalFontAwesome.php
@@ -2,13 +2,12 @@
 
 namespace Aerni\FontAwesome\FontAwesome;
 
-use Aerni\FontAwesome\Contracts\FontAwesome;
 use Aerni\FontAwesome\Data\Icons;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 use Statamic\Facades\YAML;
 
-class LocalFontAwesome extends AbstractFontAwesome implements FontAwesome
+class LocalFontAwesome extends AbstractFontAwesome
 {
     public function __construct(protected string $metadata, protected string $css)
     {

--- a/src/Http/Controllers/FontAwesomeController.php
+++ b/src/Http/Controllers/FontAwesomeController.php
@@ -4,11 +4,14 @@ namespace Aerni\FontAwesome\Http\Controllers;
 
 use Aerni\FontAwesome\Facades\FontAwesome;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Cache;
 
 class FontAwesomeController extends Controller
 {
     public function __invoke()
     {
-        return response()->json(FontAwesome::icons());
+        $json = Cache::rememberForever('font_awesome::icons', fn () => FontAwesome::icons()->toJson());
+
+        return response($json)->header('Content-Type', 'application/json');
     }
 }


### PR DESCRIPTION
When using a Font Awesome Pro kit with all icon styles enabled, the addon caches 53,665+ icons as serialized PHP objects. Deserializing these on every request costs ~85 MB peak memory, potentially crashing PHP by exceeding the default 128 MB memory limit.

This change caches the JSON response and icon styles separately, avoiding the expensive deserialization on subsequent requests.

**Peak memory usage**

| | Before | After | Reduction |
|---|---|---|---|
| **Cold cache** | 84.6 MB | 59.2 MB | -30% |
| **Warm cache** | 84.6 MB | 39.2 MB | -54% |